### PR TITLE
Add journal persistance and safety checks

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,6 +32,11 @@ android {
 }
 
 dependencies {
+    val room_version = "2.5.1"
+    implementation("androidx.room:room-runtime:$room_version")
+    annotationProcessor("androidx.room:room-compiler:$room_version")
+
+
     implementation("com.google.android.gms:play-services-auth:20.7.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.8.0")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,9 @@
             android:name=".MainActivity"
             android:exported="false" />
         <activity
+            android:name=".journal.JournalViewActivity"
+            android:exported="false" />
+        <activity
             android:name=".AuthenticationActivity"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/com/example/group10_sqa_mentalhealthapp/AppDatabase.java
+++ b/app/src/main/java/com/example/group10_sqa_mentalhealthapp/AppDatabase.java
@@ -1,0 +1,12 @@
+package com.example.group10_sqa_mentalhealthapp;
+
+import androidx.room.Database;
+import androidx.room.RoomDatabase;
+
+import com.example.group10_sqa_mentalhealthapp.journal.JournalEntry;
+import com.example.group10_sqa_mentalhealthapp.journal.JournalEntryDao;
+
+@Database(entities = {JournalEntry.class}, version = 1)
+public abstract class AppDatabase extends RoomDatabase {
+    public abstract JournalEntryDao journalEntryDao();
+}

--- a/app/src/main/java/com/example/group10_sqa_mentalhealthapp/Converters.java
+++ b/app/src/main/java/com/example/group10_sqa_mentalhealthapp/Converters.java
@@ -1,0 +1,17 @@
+package com.example.group10_sqa_mentalhealthapp;
+
+import androidx.room.TypeConverter;
+
+import java.util.Date;
+
+public class Converters {
+    @TypeConverter
+    public static Date fromTimestamp(Long value) {
+        return value == null ? null : new Date(value);
+    }
+
+    @TypeConverter
+    public static Long dateToTimestamp(Date date) {
+        return date == null ? null : date.getTime();
+    }
+}

--- a/app/src/main/java/com/example/group10_sqa_mentalhealthapp/JournalEntry.java
+++ b/app/src/main/java/com/example/group10_sqa_mentalhealthapp/JournalEntry.java
@@ -1,9 +1,0 @@
-package com.example.group10_sqa_mentalhealthapp;
-
-import java.time.LocalDateTime;
-import java.util.Date;
-
-public class JournalEntry {
-    public String content;
-    public Date localDateTime;
-}

--- a/app/src/main/java/com/example/group10_sqa_mentalhealthapp/ScreenSlidePagerAdapter.java
+++ b/app/src/main/java/com/example/group10_sqa_mentalhealthapp/ScreenSlidePagerAdapter.java
@@ -5,6 +5,8 @@ import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.Lifecycle;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 
+import com.example.group10_sqa_mentalhealthapp.journal.JournalFragment;
+
 public class ScreenSlidePagerAdapter extends FragmentStateAdapter {
     public ScreenSlidePagerAdapter(FragmentManager fm, Lifecycle lifecycle) {
         super(fm, lifecycle);

--- a/app/src/main/java/com/example/group10_sqa_mentalhealthapp/journal/JournalEntry.java
+++ b/app/src/main/java/com/example/group10_sqa_mentalhealthapp/journal/JournalEntry.java
@@ -1,0 +1,25 @@
+package com.example.group10_sqa_mentalhealthapp.journal;
+
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+import androidx.room.TypeConverters;
+
+import com.example.group10_sqa_mentalhealthapp.Converters;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Entity(tableName = "journal_entries")
+@TypeConverters({Converters.class})
+public class JournalEntry implements Serializable {
+    @PrimaryKey(autoGenerate = true)
+    public long id;
+
+    @ColumnInfo(name = "content")
+    public String content;
+
+    @ColumnInfo(name = "timestamp")
+    public Date localDateTime;
+}

--- a/app/src/main/java/com/example/group10_sqa_mentalhealthapp/journal/JournalEntryAdapter.java
+++ b/app/src/main/java/com/example/group10_sqa_mentalhealthapp/journal/JournalEntryAdapter.java
@@ -1,4 +1,4 @@
-package com.example.group10_sqa_mentalhealthapp;
+package com.example.group10_sqa_mentalhealthapp.journal;
 
 import android.view.LayoutInflater;
 import android.view.View;
@@ -8,14 +8,24 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.example.group10_sqa_mentalhealthapp.R;
+
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.List;
+import java.util.Locale;
 
 public class JournalEntryAdapter extends RecyclerView.Adapter<JournalEntryAdapter.JournalEntryHolder> {
-    private final List<JournalEntry> entries;
+    private List<JournalEntry> entries;
+    private final OnJournalItemClickListener listener;
 
-    public JournalEntryAdapter(List<JournalEntry> entries) {
+    public JournalEntryAdapter(List<JournalEntry> entries, OnJournalItemClickListener listener) {
+        this.entries = entries;
+        this.listener = listener;
+    }
+
+    public void setEntries(List<JournalEntry> entries)
+    {
         this.entries = entries;
     }
 
@@ -29,9 +39,10 @@ public class JournalEntryAdapter extends RecyclerView.Adapter<JournalEntryAdapte
 
     @Override
     public void onBindViewHolder(@NonNull JournalEntryHolder holder, int position) {
-        DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm");
+        DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm", Locale.getDefault());
         JournalEntry entry = entries.get(position);
         holder.contentsTextView.setText(entry.content);
+        holder.itemView.setOnClickListener(v -> listener.onItemClick(entry));
         holder.dateTextView.setText(dateFormat.format(entry.localDateTime));
     }
 

--- a/app/src/main/java/com/example/group10_sqa_mentalhealthapp/journal/JournalEntryDao.java
+++ b/app/src/main/java/com/example/group10_sqa_mentalhealthapp/journal/JournalEntryDao.java
@@ -1,0 +1,22 @@
+package com.example.group10_sqa_mentalhealthapp.journal;
+
+import androidx.lifecycle.LiveData;
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.Query;
+
+import java.util.List;
+
+@Dao
+public interface JournalEntryDao {
+    @Insert
+    void insert(JournalEntry entry);
+
+    @Query("SELECT * FROM journal_entries")
+    LiveData<List<JournalEntry>> getAllEntries();
+
+    @Delete
+    void delete(JournalEntry entry);
+}
+

--- a/app/src/main/java/com/example/group10_sqa_mentalhealthapp/journal/JournalRepository.java
+++ b/app/src/main/java/com/example/group10_sqa_mentalhealthapp/journal/JournalRepository.java
@@ -1,0 +1,40 @@
+package com.example.group10_sqa_mentalhealthapp.journal;
+
+import android.app.Application;
+
+import androidx.lifecycle.LiveData;
+import androidx.room.Room;
+
+import com.example.group10_sqa_mentalhealthapp.AppDatabase;
+
+import java.util.List;
+
+public class JournalRepository {
+    private static JournalRepository instance;
+    private final JournalEntryDao dao;
+
+    private JournalRepository(Application application) {
+        AppDatabase db = Room.databaseBuilder(application,
+                AppDatabase.class, "journal_database").build();
+        dao = db.journalEntryDao();
+    }
+
+    public static synchronized JournalRepository getInstance(Application application) {
+        if (instance == null) {
+            instance = new JournalRepository(application);
+        }
+        return instance;
+    }
+
+    LiveData<List<JournalEntry>> getAllEntries() {
+        return dao.getAllEntries();
+    }
+
+    void addEntry(JournalEntry entry) {
+        new Thread(() -> dao.insert(entry)).start();
+    }
+
+    void deleteEntry(JournalEntry entry) {
+        new Thread(() -> dao.delete(entry)).start();
+    }
+}

--- a/app/src/main/java/com/example/group10_sqa_mentalhealthapp/journal/JournalViewActivity.java
+++ b/app/src/main/java/com/example/group10_sqa_mentalhealthapp/journal/JournalViewActivity.java
@@ -1,0 +1,74 @@
+package com.example.group10_sqa_mentalhealthapp.journal;
+
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+import com.example.group10_sqa_mentalhealthapp.R;
+
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+
+public class JournalViewActivity extends AppCompatActivity {
+
+    private JournalEntry journalEntry;
+    private TextView journalContentTextView;
+    private TextView journalTimestampTextView;
+    private Button deleteButton;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_journalview);
+
+        // Initialize views and database
+        initializeViews();
+
+        // Get the JournalEntry from the intent or saved state
+        retrieveJournalEntry(savedInstanceState);
+
+        // Display the journal entry details
+        displayJournalEntry();
+
+        // Setup delete button
+        setupDeleteButton();
+    }
+
+    private void initializeViews() {
+        journalContentTextView = findViewById(R.id.journal_content);
+        journalTimestampTextView = findViewById(R.id.journal_timestamp);
+        deleteButton = findViewById(R.id.delete_button);
+    }
+
+    private void retrieveJournalEntry(Bundle savedInstanceState) {
+        if (savedInstanceState != null && savedInstanceState.containsKey("journalEntry")) {
+            journalEntry = (JournalEntry) savedInstanceState.getSerializable("journalEntry");
+        } else {
+            journalEntry = (JournalEntry) getIntent().getSerializableExtra("journalEntry");
+        }
+    }
+
+    private void displayJournalEntry() {
+        if (journalEntry != null) {
+            journalContentTextView.setText(journalEntry.content);
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault());
+            journalTimestampTextView.setText(dateFormat.format(journalEntry.localDateTime));
+        }
+    }
+
+    private void setupDeleteButton() {
+        deleteButton.setOnClickListener(v -> deleteEntry());
+    }
+
+    private void deleteEntry() {
+        JournalRepository.getInstance(getApplication()).deleteEntry(journalEntry);
+        finish(); // Close the activity
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putSerializable("journalEntry", journalEntry);
+    }
+}

--- a/app/src/main/java/com/example/group10_sqa_mentalhealthapp/journal/OnJournalItemClickListener.java
+++ b/app/src/main/java/com/example/group10_sqa_mentalhealthapp/journal/OnJournalItemClickListener.java
@@ -1,0 +1,8 @@
+package com.example.group10_sqa_mentalhealthapp.journal;
+
+import com.example.group10_sqa_mentalhealthapp.journal.JournalEntry;
+
+public interface OnJournalItemClickListener {
+    void onItemClick(JournalEntry journalEntry);
+}
+

--- a/app/src/main/java/com/example/group10_sqa_mentalhealthapp/safety/ContentSafetyHandler.java
+++ b/app/src/main/java/com/example/group10_sqa_mentalhealthapp/safety/ContentSafetyHandler.java
@@ -1,0 +1,67 @@
+package com.example.group10_sqa_mentalhealthapp.safety;
+
+import android.content.Context;
+import android.text.Layout;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.example.group10_sqa_mentalhealthapp.R;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ContentSafetyHandler {
+    private static ContentSafetyHandler instance;
+    private final Set<String> safetyWords;
+    private Toast currentDistressToast;
+
+    private ContentSafetyHandler() {
+        // Initialize the set of safety words
+        // todo: obviously consult a professional list instead of hardcore some terms lol
+        safetyWords = new HashSet<>(Arrays.asList("suicide", "kill myself", "abuse", "abusive", "kill me", "end myself", "i want to die"));
+    }
+
+    public static synchronized ContentSafetyHandler getInstance() {
+        if (instance == null) {
+            instance = new ContentSafetyHandler();
+        }
+        return instance;
+    }
+
+    public boolean checkContents(String text) {
+        for (String word : safetyWords) {
+            if (text.toLowerCase().contains(word.toLowerCase())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void showDistressMessage(LayoutInflater inflater, Context context)
+    {
+        if (currentDistressToast != null)
+        {
+            currentDistressToast.cancel();
+        }
+
+        View layout = inflater.inflate(R.layout.custom_toast_layout, null);
+
+        TextView text = layout.findViewById(R.id.custom_toast_message);
+        
+        text.setText(context.getString(
+                R.string.distress_message)
+                + System.lineSeparator()
+                + System.lineSeparator()
+                + context.getString(R.string.distress_message_contact));
+
+        Toast toast = new Toast(context);
+        toast.setDuration(Toast.LENGTH_LONG);
+        toast.setView(layout);
+        toast.show();
+
+        currentDistressToast = toast;
+    }
+}

--- a/app/src/main/res/drawable/rounded_background.xml
+++ b/app/src/main/res/drawable/rounded_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/red" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/layout/activity_journalview.xml
+++ b/app/src/main/res/layout/activity_journalview.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".journal.JournalViewActivity">
+
+    <!-- Timestamp for the Journal Entry -->
+    <TextView
+        android:id="@+id/journal_timestamp"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="Timestamp"
+        android:textSize="18sp"
+        android:textAlignment="center"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent" />
+
+    <!-- CardView for Text Content of the Journal Entry -->
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/journal_card"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:cardCornerRadius="8dp"
+        app:cardElevation="4dp"
+        app:layout_constraintTop_toBottomOf="@id/journal_timestamp"
+        app:layout_constraintBottom_toTopOf="@id/delete_button"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintVertical_bias="0.0"
+        android:layout_margin="16dp">
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <TextView
+                android:id="@+id/journal_content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Journal Entry Content"
+                android:textSize="16sp"
+                android:padding="16dp"/>
+        </ScrollView>
+    </com.google.android.material.card.MaterialCardView>
+
+    <!-- Delete Button -->
+    <Button
+        android:id="@+id/delete_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/journal_delete_text"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/custom_toast_layout.xml
+++ b/app/src/main/res/layout/custom_toast_layout.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:background="@drawable/rounded_background"
+    android:padding="10dp">
+
+    <TextView
+    android:id="@+id/custom_toast_message"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:textColor="@android:color/white"
+    android:textSize="16sp" />
+</LinearLayout>
+

--- a/app/src/main/res/layout/fragment_journal.xml
+++ b/app/src/main/res/layout/fragment_journal.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:padding="16dp"
-    tools:context=".JournalFragment">
+    tools:context=".journal.JournalFragment">
 
     <!-- Text Area for Journal Entry -->
     <EditText

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="red">#EE3333</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,5 +9,8 @@
     <string name="blurt_switch_text">Blurt</string>
     <string name="journal_hint_text">Write your journal entry here</string>
     <string name="journal_submit_text">Submit</string>
+    <string name="journal_delete_text">Delete</string>
     <string name="journal_entry_header_text">Your Entries</string>
+    <string name="distress_message">If you\'re feeling distressed, please reach out for support.</string>
+    <string name="distress_message_contact">Call 116 123 to contact the Samaritans</string>
 </resources>


### PR DESCRIPTION
Hi if this could be checked for tonight:

- Adds persistence via room
- Adds new dependency (room) over sqllite
- Adds a content safety checker that atm uses a hardcoded list (change later) with a temporary distress message
- Adds the ability to delete journal entries
- Adds a new journal entry view (click on an entry)

Needs to have more fixes in the future
(add pincode lock, add edit button + hook up to delete all)